### PR TITLE
Build Fix Attempt

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Specifically, meant to show a problem I am facing.
 ## Running Tests through ScalaTest cli
 1. `cd docker` (The compiled jars are copied to this folder, where we already have the scalatest jars)
 2. Running individual tests: 
-    `scala -J-Xmx2g -cp "scalatest_2.11-3.0.5.jar:scalactic_2.11-3.0.5.jar" org.scalatest.tools.Runner -o -R try-scalatest-1.0-SNAPSHOT-test.jar -s com.tfs.test.MyTest1` 
+    `scala -J-Xmx2g -cp "scalatest_2.11-3.0.5.jar:scalactic_2.11-3.0.5.jar:try-scalatest-1.0-SNAPSHOT.jar" org.scalatest.tools.Runner -o -R try-scalatest-1.0-SNAPSHOT-tests.jar -s com.tfs.test.MyTest1` 
     
-    `scala -J-Xmx2g -cp "scalatest_2.11-3.0.5.jar:scalactic_2.11-3.0.5.jar" org.scalatest.tools.Runner -o -R try-scalatest-1.0-SNAPSHOT-test.jar -s com.tfs.test.MyTest2`
+    `scala -J-Xmx2g -cp "scalatest_2.11-3.0.5.jar:scalactic_2.11-3.0.5.jar:try-scalatest-1.0-SNAPSHOT.jar" org.scalatest.tools.Runner -o -R try-scalatest-1.0-SNAPSHOT-tests.jar -s com.tfs.test.MyTest2`
     
 3. Running all tests together:
-    `scala -J-Xmx2g -cp "scalatest_2.11-3.0.5.jar:scalactic_2.11-3.0.5.jar" org.scalatest.tools.Runner -o -R try-scalatest-1.0-SNAPSHOT-test.jar`
+    `scala -J-Xmx2g -cp "scalatest_2.11-3.0.5.jar:scalactic_2.11-3.0.5.jar:try-scalatest-1.0-SNAPSHOT.jar" org.scalatest.tools.Runner -o -R try-scalatest-1.0-SNAPSHOT-tests.jar`
     
     This is currently failing with the following message:
     <pre>

--- a/pom.xml
+++ b/pom.xml
@@ -118,27 +118,13 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
+                <artifactId>maven-jar-plugin</artifactId>
                 <version>3.1.0</version>
-                <configuration>
-                    <descriptors>
-                        <descriptor>src/main/assembly/assembly.xml</descriptor>
-                    </descriptors>
-                </configuration>
                 <executions>
                     <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
                         <goals>
-                            <goal>single</goal>
+                            <goal>test-jar</goal>
                         </goals>
-                        <configuration>
-                            <archive>
-                                <manifest>
-                                    <mainClass>com.tfs.test.MyTest1</mainClass>
-                                </manifest>
-                            </archive>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -190,7 +176,7 @@
                                     <directory>${basedir}/target</directory>
                                     <includes>
                                         <include>${project.name}-${project.version}.jar</include>
-                                        <include>${project.name}-${project.version}-test.jar</include>
+                                        <include>${project.name}-${project.version}-tests.jar</include>
                                     </includes>
                                 </resource>
                             </resources>


### PR DESCRIPTION
Adjusted the build to include test classes only in the tests jar, as it speeds up discovery of test classes and it is really no need to scan every classes in the assembly jar to discover tests, the encountered error of IllegalAccessError probably comes from class loading issue in the dependencies tree.